### PR TITLE
ggh should be able to clone projects with ".git" suffix

### DIFF
--- a/ggh
+++ b/ggh
@@ -57,7 +57,7 @@ cmd_gerrit_clone () {
     echo
 
     git clone $1
-    project=`echo $1 | sed -E "s/.*\///"`
+    project=`echo $1 | sed -E "s/.*\///" | sed -E "s/\.git$//"`
     gerrit=`echo $1 | sed -E "s/ssh:\/\/([^:\/]*).*/\1/"`
     cd $project
     scp $gerrit:hooks/commit-msg .git/hooks


### PR DESCRIPTION
Git allows to clone projects from Gerrit by its full name that includes
.git suffix as well

git gerrit-clone ssh://server:29148/foo/bar.git

and output directory in this case is 'bar', not 'bar.git'
ggh should handle it correctly and strip the suffix from url.
