### PR TITLE
Allow user to upload with dirty status

### DIFF
--- a/ggh
+++ b/ggh
@@ -93,7 +93,6 @@ cmd_start () {
 }
 
 cmd_upload () {
-    ensure_status_clean
 
     local_branch=`git symbolic-ref HEAD | sed -e 's|^refs/heads/||'`
     remote_branch=`git config branch.$local_branch.merge | sed -e 's|^refs/heads/||'`


### PR DESCRIPTION
ordinarily I would stash away unstaged changes before running ggh upload, but this isn't possible when there are untracked files in the repository.
